### PR TITLE
update for dcrticketbuyer changes

### DIFF
--- a/cmd/dcrinstall/README.md
+++ b/cmd/dcrinstall/README.md
@@ -208,11 +208,6 @@ version).
 dcrinstall has been tested on Windows 10, Windows 7, OSX 10.11, Bitrig current,
 OpenBSD, Fedora, Ubuntu, and Raspbian.
 
-Due to an issue with the go cross-compiler, binaries are not available
-for linux-arm64.  Users running Linux on arm64 should either build
-from source or contact the decred developers for a binary for that
-platform.
-
 ## License
 
 dcrinstall is licensed under the [copyfree](http://copyfree.org) ISC

--- a/cmd/dcrinstall/dcrinstall.go
+++ b/cmd/dcrinstall/dcrinstall.go
@@ -454,10 +454,6 @@ func (c *ctx) createConfigTicketbuyer(b binary, f *os.File) (string, error) {
 		case strings.HasPrefix(line, "httpsvrport"):
 			// use default from config file
 
-		case strings.HasPrefix(line, "httpuipath"):
-			dir := filepath.Join(c.s.Destination, "webui")
-			line = fmt.Sprintf("httpuipath=%v\n", dir)
-
 		case strings.HasPrefix(line, "simnet"):
 			a := "0"
 			if c.s.Net == netSim {


### PR DESCRIPTION
dcrticketbuyer now follows the same naming scheme as the other programs in the dcr\* suite.

httpuipath has been removed as it is no longer necessary.

Also capitalized Decred where appropriate and removed the cross compiling errata since that has been fixed.
