### PR TITLE
don't need to copy directories anymore; fixes windows upgrade race

### DIFF
--- a/cmd/dcrinstall/dcrinstall.go
+++ b/cmd/dcrinstall/dcrinstall.go
@@ -295,17 +295,6 @@ func (c *ctx) copy(version string) error {
 		}
 	}
 
-	// non binaries
-	filename := filepath.Join(c.s.Destination,
-		"decred-"+c.s.Tuple+"-"+version)
-
-	c.log("installing: %v -> %v\n", filename, c.s.Destination)
-
-	err := archive.CopyResource(filename, c.s.Destination+"/", false)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Since webui was removed, the directory copying code introduced a race on Windows:

09:35:44.126 installing: C:\Users\jolan\decred\decred-windows-amd64-v0.4.0 -> C:\Users\jolan\decred
time="2016-09-07T09:35:44-05:00" level=error msg="Can't add file \\?\C:\Users\jolan\decred\decred-windows-amd64-v0.4.0\dcrctl.exe to tar: io: read/write on closed pipe"
time="2016-09-07T09:35:44-05:00" level=error msg="Can't close tar writer: io: read/write on closed pipe"
09:35:44.194 remove C:\Users\jolan\decred\decred-windows-amd64-v0.4.0\dcrctl.exe: The process cannot access the file because it is being used by another process

It was copying the directory which is unnecessary.  This caused the files to be considered in use and caused the upgrade to "fail" right at the end.
