### PR TITLE
bump for 1.0.8 and fix sample-dcrd.conf handling

### DIFF
--- a/cmd/dcrinstall/dcrinstall.go
+++ b/cmd/dcrinstall/dcrinstall.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/sampleconfig"
 	"github.com/decred/dcrutil"
 	"github.com/decred/dcrwallet/loader"
 	"github.com/decred/dcrwallet/prompt"
@@ -43,6 +44,7 @@ type binary struct {
 	Name            string // binary filename
 	Config          string // actual config file
 	Example         string // example config file
+	ExampleGenerate bool   // whether or not to generate the example config
 	SupportsVersion bool   // whether or not it supports --version
 }
 
@@ -56,6 +58,9 @@ var (
 		},
 		{
 			Name:            "dcrd",
+			Config:          "dcrd.conf",
+			Example:         "sample-dcrd.conf",
+			ExampleGenerate: true,
 			SupportsVersion: true,
 		},
 		{
@@ -422,11 +427,23 @@ func (c *ctx) createConfigNormal(b binary, f *os.File) (string, error) {
 }
 
 func (c *ctx) createConfig(b binary, version string) (string, error) {
-	// read sample config
 	sample := filepath.Join(c.s.Destination,
 		"decred-"+c.s.Tuple+"-"+version,
 		b.Example)
 
+	// write sample config if needed
+	if b.ExampleGenerate {
+		switch b.Name {
+		case "dcrd":
+			err := ioutil.WriteFile(sample, []byte(sampleconfig.FileContents), 0644)
+			if err != nil {
+				return "", fmt.Errorf("unable to write sample config to %v: %v",
+					sample, err)
+			}
+		}
+	}
+
+	// read sample config
 	f, err := os.Open(sample)
 	if err != nil {
 		return "", err

--- a/cmd/dcrinstall/settings.go
+++ b/cmd/dcrinstall/settings.go
@@ -17,8 +17,8 @@ import (
 
 // latestVersion and latestManifest must be updated every release.
 const (
-	latestManifest = "manifest-v1.0.7.txt"
-	defaultURI     = "https://github.com/decred/decred-binaries/releases/download/v1.0.7"
+	latestManifest = "manifest-v1.0.8.txt"
+	defaultURI     = "https://github.com/decred/decred-binaries/releases/download/v1.0.8"
 
 	netMain  = "mainnet"
 	netTest  = "testnet"

--- a/cmd/dcrinstall/version.go
+++ b/cmd/dcrinstall/version.go
@@ -19,7 +19,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	appMajor uint = 1
 	appMinor uint = 0
-	appPatch uint = 7
+	appPatch uint = 8
 
 	// appPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b9a3ad4c9d42e59c401f803f81170c189493f33879c1a5a9dc4e622dbaaabece
-updated: 2017-08-21T17:12:29.0364377-04:00
+hash: c94c15d4dee0fdd0ab919b101ad7eeb070ce46580c1ef97aba63d0c9caf9c71f
+updated: 2017-08-25T12:18:28.690233768-05:00
 imports:
 - name: github.com/agl/ed25519
   version: 278e1ec8e8a6e017cd07577924d6766039146ced
@@ -15,12 +15,12 @@ imports:
   - socks
 - name: github.com/btcsuite/websocket
   version: 31079b6807923eb23992c421b114992b95131b55
+- name: github.com/dchest/blake256
+  version: dee3fe6eb0e98dc774a94fc231f85baf7c29d360
 - name: github.com/decred/bitset
   version: 484b833245d5f9046e2893a6bd2e54b1df3a53a4
-- name: github.com/decred/blake256
-  version: a840e32d7c31fe2e0218607334cb120a683951a4
 - name: github.com/decred/dcrd
-  version: 64119dfabb82f0aa30c079012737e7d73626a6ca
+  version: f0a01ced0aad52437f62b626e8ffe43c3ae689a5
   subpackages:
   - blockchain
   - blockchain/internal/dbnamespace
@@ -37,6 +37,7 @@ imports:
   - dcrec/secp256k1
   - dcrec/secp256k1/schnorr
   - dcrjson
+  - sampleconfig
   - txscript
   - wire
 - name: github.com/decred/dcrrpcclient
@@ -47,7 +48,7 @@ imports:
   - base58
   - hdkeychain
 - name: github.com/decred/dcrwallet
-  version: a2599956184c6cecce9e8c20a7d6c37e03ae84c5
+  version: 2befc6ae9e4979ca6fa72a5c900f6c1d2e13953a
   subpackages:
   - apperrors
   - chain

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,6 +4,7 @@ import:
   version: v1.0.7
   subpackages:
   - chaincfg
+  - sampleconfig
 - package: github.com/decred/dcrutil
 - package: github.com/decred/dcrwallet
   version: v1.0.7


### PR DESCRIPTION
Closes #123.

Needs https://github.com/decred/dcrd/pull/834 to go in so glide can be updated.  Tested locally and works ok for me.