### PR TITLE
bugfix: tweaks isRunning function

### DIFF
--- a/cmd/dcrinstall/util_unix.go
+++ b/cmd/dcrinstall/util_unix.go
@@ -20,7 +20,7 @@ func (c *ctx) isRunning(name string) (bool, error) {
 
 	switch runtime.GOOS {
 	case "linux":
-		args = []string{"-A", "aeww"}
+		args = []string{"aeww"}
 	default:
 		// BSD*
 		args = []string{"Aaeww"}

--- a/cmd/dcrinstall/util_unix.go
+++ b/cmd/dcrinstall/util_unix.go
@@ -45,6 +45,10 @@ func (c *ctx) isRunning(name string) (bool, error) {
 		if s == "" {
 			continue
 		}
+		
+		if len(strings.Split(s, "=")) != 2 {
+			continue
+		}
 
 		return true, nil
 	}

--- a/cmd/dcrinstall/util_unix.go
+++ b/cmd/dcrinstall/util_unix.go
@@ -45,7 +45,7 @@ func (c *ctx) isRunning(name string) (bool, error) {
 		if s == "" {
 			continue
 		}
-		
+
 		if len(strings.Split(s, "=")) != 2 {
 			continue
 		}


### PR DESCRIPTION
Well, when some process's env like is as the following on unix*:
```
 _=/usr/bin/grep OLDPWD=/data/project/dcrd-1.1.0
```
It will think the dcrd process is still running. Here we just briefly split the env variable by sep '=' to make sure only one env. But if the process env value include "=", it could meet error again. However, it's rare the env value include "=", so it's enough:)