### PR TITLE
Update to signature verification after name change manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ installers in that release.  To verify these, you will need:
 
 The steps to verify the binaries are as follows:
 
-1. Download the file manifest (manifest-dcrinstall-vX.X.X.txt), the signature for the file manifest (manifest-dcrinstall-vX.X.X.txt.asc), and the installer for your OS from [here](https://github.com/decred/decred-release/releases).
+1. Download the file manifest (dcrinstall-vX.X.X-manifest.txt), the signature for the file manifest (dcrinstall-vX.X.X-manifest.txt.asc), and the installer for your OS from [here](https://github.com/decred/decred-release/releases).
 2. Obtain the SHA256 value for the installer for your OS and check that it matches the value in the file manifest, e.g. for 64-bit Linux
 
    ```
-   $ sha256sum dcrinstall-linux-amd64-v0.3.0
-   a53004599daeab51c0e86af026748b7aa55ff9e5d4844bef3b7d8ccf8a5d72a9  dcrinstall-linux-amd64-v0.3.0
+   $ sha256sum dcrinstall-linux-amd64-v1.5.1
+   a53004599daeab51c0e86af026748b7aa55ff9e5d4844bef3b7d8ccf8a5d72a9  dcrinstall-linux-amd64-v1.5.1
    ```
 
 3. Import the Decred Release Signing Key in GnuPG.
@@ -45,8 +45,8 @@ The steps to verify the binaries are as follows:
 the Decred Release Signing Key.
 
 	```
-   $ gpg --verify manifest-dcrinstall-v0.3.0.txt.asc
-      gpg: assuming signed data in `manifest-dcrinstall-v0.3.0.txt'
+   $ gpg --verify dcrinstall-v1.5.1-manifest.txt.asc
+      gpg: assuming signed data in `manifest-dcrinstall-v1.5.1.txt'
       gpg: Signature made Wed 27 Jan 2016 08:56:59 PM UTC using RSA key ID 518A031D
       gpg: Good signature from "Decred Release <release@decred.org>"
       gpg: WARNING: This key is not certified with a trusted signature!

--- a/README.md
+++ b/README.md
@@ -34,25 +34,26 @@ The steps to verify the binaries are as follows:
 
 3. Import the Decred Release Signing Key in GnuPG.
    ```
-   $ gpg --keyserver pgp.mit.edu --recv-keys 0x6D897EDF518A031D
-      gpg: requesting key 518A031D from hkp server pgp.mit.edu
-      gpg: /home/user/.gnupg/trustdb.gpg: trustdb created
-      gpg: key 7608AF04: public key "Decred Release <release@decred.org>" imported
-      gpg: Total number processed: 1
-      gpg: imported: 1 (RSA: 1)
+   $ gpg --keyserver pgp.mit.edu --recv-keys 0x518A031D
+	gpg: keybox '/home/satoshi/.gnupg/pubring.kbx' created
+	gpg: /home/satoshi/.gnupg/trustdb.gpg: trustdb created
+	gpg: key 6DF634AA7608AF04: public key "Decred Release <release@decred.org>" imported
+	gpg: Total number processed: 1
+	gpg:               imported: 1
    ```
 4. Verify the signature for the file manifest is valid and created by
 the Decred Release Signing Key.
 
-	```
+   ```
    $ gpg --verify dcrinstall-v1.5.1-manifest.txt.asc
-      gpg: assuming signed data in `manifest-dcrinstall-v1.5.1.txt'
-      gpg: Signature made Wed 27 Jan 2016 08:56:59 PM UTC using RSA key ID 518A031D
-      gpg: Good signature from "Decred Release <release@decred.org>"
+      gpg: assuming signed data in 'dcrinstall-v1.5.1-manifest.txt'
+      gpg: Signature made Mi 29 Jan 2020 21:17:45 CET
+      gpg:                using RSA key F516ADB7A069852C7C28A02D6D897EDF518A031D
+      gpg: Good signature from "Decred Release <release@decred.org>" [unknown]
       gpg: WARNING: This key is not certified with a trusted signature!
-      gpg: There is no indication that the signature belongs to the owner.
-          Primary key fingerprint: FD13 B683 5E24 8FAF 4BD1 838D 6DF6 34AA 7608 AF04
-           Subkey fingerprint: F516 ADB7 A069 852C 7C28 A02D 6D89 7EDF 518A 031D
+      gpg:          There is no indication that the signature belongs to the owner.
+      Primary key fingerprint: FD13 B683 5E24 8FAF 4BD1  838D 6DF6 34AA 7608 AF04
+         Subkey fingerprint: F516 ADB7 A069 852C 7C28  A02D 6D89 7EDF 518A 031D
    ```
 
 The installer for your platform is now verified and you can be confident


### PR DESCRIPTION
Hi,

First pull request ever, so I'm not sure how this all works. :)

I was trying to install dcrd and came across different manifest naming convention since a few releases. I updated the README file with how I did it.

The gpg --verify command says 'Good Signature' but I can't actually find the same value in the previous step like the original example had. Did I run the commands correctly?

Cheers