### PR TITLE
Delete any previous build directory before proceeding

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -12,6 +12,7 @@ LDFLAGS="-buildid= -X main.appBuild=release"
 PWD=$(pwd)
 PACKAGE=dcrinstall
 MAINDIR=$PWD/release/$PACKAGE-$TAG
+[ -d ${MAINDIR} ] && rm -rf ${MAINDIR}
 mkdir -p $MAINDIR
 
 SYS="darwin-amd64 freebsd-amd64 linux-386 linux-amd64 linux-arm linux-arm64 openbsd-amd64 windows-386 windows-amd64"


### PR DESCRIPTION
When an old build directory exists, the previous manifest becomes
hashed and committed to in a new manifest file.  This hash will always
be invalid when checking sums, as the file cannot commit to itself.