### PR TITLE
Copy site directory and do not try to see if it is running

### DIFF
--- a/cmd/dcrinstall/bitcoin.go
+++ b/cmd/dcrinstall/bitcoin.go
@@ -134,6 +134,9 @@ func preconditionsBitcoinInstall() error {
 	// Abort if a daemon is still running
 	var isRunningList []string
 	for k := range bitcoinf {
+		if bitcoinf[k].Directory {
+			continue
+		}
 		name := bitcoinf[k].Name
 		ok, err := isRunning(name)
 		if err != nil {
@@ -390,7 +393,8 @@ func installBitcoinBundle() error {
 			"bitcoin-"+manifestBitcoinVersion, "bin", name)
 		dst := filepath.Join(destination, name)
 		// yep, this is ferrealz
-		if strings.HasPrefix(tuple, "windows") {
+		if !bitcoinf[k].Directory &&
+			strings.HasPrefix(tuple, "windows") {
 			src += ".exe"
 			dst += ".exe"
 		}

--- a/cmd/dcrinstall/dcrdex.go
+++ b/cmd/dcrinstall/dcrdex.go
@@ -31,6 +31,10 @@ var (
 			SampleMemory:    dexcSampleConfig,
 			SupportsVersion: true,
 		},
+		{
+			Name:      "site",
+			Directory: true,
+		},
 	}
 )
 
@@ -75,6 +79,9 @@ func preconditionsDcrdexInstall() error {
 	// Abort if a daemon is still running
 	var isRunningList []string
 	for k := range dexf {
+		if dexf[k].Directory {
+			continue
+		}
 		ok, err := isRunning(dexf[k].Name)
 		if err != nil {
 			return fmt.Errorf("isRunning: %v", err)
@@ -322,7 +329,7 @@ func installDcrdexBundle() error {
 			"dexc-"+tuple+"-"+manifestDcrdexVersion, dexf[k].Name)
 		dst := filepath.Join(destination, dexf[k].Name)
 		// yep, this is ferrealz
-		if strings.HasPrefix(tuple, "windows") {
+		if !dexf[k].Directory && strings.HasPrefix(tuple, "windows") {
 			src += ".exe"
 			dst += ".exe"
 		}

--- a/cmd/dcrinstall/decred.go
+++ b/cmd/dcrinstall/decred.go
@@ -33,6 +33,7 @@ type decredFiles struct {
 	SampleFilename  string // Sample file config file
 	SampleMemory    string // Static sample config
 	SupportsVersion bool   // Whether or not it supports --version
+	Directory       bool   // Whether or not this filename is a directory
 }
 
 var (
@@ -210,6 +211,9 @@ func preconditionsDecredInstall() error {
 	// Abort if a daemon is still running
 	var isRunningList []string
 	for k := range df {
+		if df[k].Directory {
+			continue
+		}
 		ok, err := isRunning(df[k].Name)
 		if err != nil {
 			return fmt.Errorf("isRunning: %v", err)
@@ -519,7 +523,7 @@ func installDecredBundle() error {
 			"decred-"+tuple+"-"+manifestDecredVersion, df[k].Name)
 		dst := filepath.Join(destination, df[k].Name)
 		// yep, this is ferrealz
-		if strings.HasPrefix(tuple, "windows") {
+		if !df[k].Directory && strings.HasPrefix(tuple, "windows") {
 			src += ".exe"
 			dst += ".exe"
 		}


### PR DESCRIPTION
Somehow during rebase the copy of the dexc `site` directory was lost. Add it back in and make sure it is removed prior to installation. Also, do not try to see is directory types are running.