### PR TITLE
Use config filename as hint for target directory.

### DIFF
--- a/cmd/dcrinstall/bitcoin.go
+++ b/cmd/dcrinstall/bitcoin.go
@@ -209,7 +209,8 @@ func preconditionsBitcoinInstall() error {
 
 		expectedConfigFiles++
 
-		name := bitcoinf[k].Name
+		ext := filepath.Ext(bitcoinf[k].Config)
+		name := strings.TrimSuffix(bitcoinf[k].Config, ext)
 		dir := dcrutil.AppDataDir(name, true)
 		filename := filepath.Join(dir, bitcoinf[k].Config)
 		if exists(filename) {
@@ -335,7 +336,8 @@ func installBitcoinBundleConfig() error {
 		}
 
 		// Check if the config file is already installed.
-		name := bitcoinf[k].Name
+		ext := filepath.Ext(bitcoinf[k].Config)
+		name := strings.TrimSuffix(bitcoinf[k].Config, ext)
 		dir := dcrutil.AppDataDir(name, true)
 		dst := filepath.Join(dir, bitcoinf[k].Config)
 		if exists(dst) {

--- a/cmd/dcrinstall/dcrdex.go
+++ b/cmd/dcrinstall/dcrdex.go
@@ -152,7 +152,9 @@ func preconditionsDcrdexInstall() error {
 
 		expectedConfigFiles++
 
-		dir := dcrutil.AppDataDir(dexf[k].Name, false)
+		ext := filepath.Ext(dexf[k].Config)
+		name := strings.TrimSuffix(dexf[k].Config, ext)
+		dir := dcrutil.AppDataDir(name, false)
 		filename := filepath.Join(dir, dexf[k].Config)
 		if exists(filename) {
 			log.Printf("Config %s -- already installed", filename)
@@ -275,7 +277,9 @@ func installDcrdexBundleConfig() error {
 		}
 
 		// Check if the config file is already installed.
-		dir := dcrutil.AppDataDir(dexf[k].Name, false)
+		ext := filepath.Ext(dexf[k].Config)
+		name := strings.TrimSuffix(dexf[k].Config, ext)
+		dir := dcrutil.AppDataDir(name, false)
 		dst := filepath.Join(dir, dexf[k].Config)
 		if exists(dst) {
 			continue

--- a/cmd/dcrinstall/decred.go
+++ b/cmd/dcrinstall/decred.go
@@ -27,9 +27,13 @@ const (
 
 // decredFiles provides all needed bits to perform the install the decred
 // bundle.
+//
+// Note: The Config filename determines the target directory name. This is a
+// necessary override where some daemons names end in d but the target
+// directory and config file do not have the trailing d in the name.
 type decredFiles struct {
 	Name            string // Binary filename
-	Config          string // Actual config file
+	Config          string // Actual config file.
 	SampleFilename  string // Sample file config file
 	SampleMemory    string // Static sample config
 	SupportsVersion bool   // Whether or not it supports --version
@@ -284,7 +288,9 @@ func preconditionsDecredInstall() error {
 
 		expectedConfigFiles++
 
-		dir := dcrutil.AppDataDir(df[k].Name, false)
+		ext := filepath.Ext(df[k].Config)
+		name := strings.TrimSuffix(df[k].Config, ext)
+		dir := dcrutil.AppDataDir(name, false)
 		filename := filepath.Join(dir, df[k].Config)
 		if exists(filename) {
 			log.Printf("Config %s -- already installed", filename)
@@ -408,7 +414,9 @@ func installDecredBundleConfig() error {
 		}
 
 		// Check if the config file is already installed.
-		dir := dcrutil.AppDataDir(df[k].Name, false)
+		ext := filepath.Ext(df[k].Config)
+		name := strings.TrimSuffix(df[k].Config, ext)
+		dir := dcrutil.AppDataDir(name, false)
 		dst := filepath.Join(dir, df[k].Config)
 		if exists(dst) {
 			continue


### PR DESCRIPTION
Bitcoin differs from all other daemons where the daemon name does not
match the configuration and target directory name. Instead of relying on
the daemon name use the configuration name instead to determine what the
target directory is. This change was made over all 3 components that are
being installed.