### PR TITLE
Update dcrinstall latest manifest

### DIFF
--- a/latest
+++ b/latest
@@ -4,20 +4,20 @@ Hash: SHA256
 d3b403f9f0c9e754d89043f04289cdcd461a5bcadf56d95753b12d35e64069e7  https://github.com/decred/decred-binaries/releases/download/v1.6.2/decred-v1.6.2-manifest.txt
 3b57a75354007acaf5a635b27a604cb16caeabfe81a2c09e981399b769d6ee95  https://github.com/decred/decred-binaries/releases/download/v1.6.2/dexc-v0.1.5-manifest.txt
 ca9e8202740648542d7b81c9ba1a6f612dc99f919b61db294462256de3a9d27d  https://github.com/decred/decred-release/releases/download/v1.6.2/dcrinstall-v1.6.2-manifest.txt
-b5c04fe37b40119bdc2d329b9c8fb9c0b402a10388fd0837d1a30fb0cd99b344  https://bitcoincore.org/bin/bitcoin-core-0.20.1/SHA256SUMS.asc
+9ae534c116c22cee5bd7e580cf87a5472ceb04c9df46db2cd449add161e3c165  https://bitcoincore.org/bin/bitcoin-core-0.20.1/SHA256SUMS.asc
 -----BEGIN PGP SIGNATURE-----
 
-iQIzBAEBCAAdFiEE9Ratt6BphSx8KKAtbYl+31GKAx0FAmBvKIIACgkQbYl+31GK
-Ax1H9Q//QQy80sxGU/6q8g379U1S9XFhHN/3Wdt7qoCKzINED10cyaCCPcUz9IR9
-khPjhe50un5idyQ/H0s+DrqvxxU0VlkkOL3iJ3Z2BRdAQcbhB29LsPya9SODwZyd
-cGKG1RQaysihh/4SolzQrozECcO0B/RG9DVlV/A5AgzZ84OmfcjLQqInk5Bg0g8T
-4thSyJQy3H78FMBP1wzm3aAUxUJ8puQpiI9ivqUAcW4A6jEgxaqQyxmHCQ150pQO
-joPcRxqUDrKXC4vyKzlAF0SM9kZxVolGJUyY/jugue/BRy0joa8+W94PoEqeNcJq
-lJeeDL8bTg8ToyDXOYMSapN7vocnEg/cu99j2nkhD6ljBJ1xgjtMCf2EpztkiGqQ
-Yu2slZfiLP5OQpajp+8spyk6ebDzCwL/WZi9Rf+GpnHF+iKlahiZGT9cGMR6OS7/
-C6c5upZ3F7gsU+ksY1rWPexGtaIM1lnogPvItKonazgWCkn+3BLDblg0X04wUsI9
-IGSkOhwm2+9Qj1EU/BAaLgenveuiZKLDeI8WsNs1iFR0BIs8T0eUt+IuYrMxsF3E
-7hE3xf52AvJo4gS4PjOmyH8RonRWZiGGppfbmFcOeawgWt3D5NLvFxI9Nk77cqCg
-DFMjUpzHDo/Vc/rtOobN7MQX5q2ddYP9c5gZFdZzFJskqgMUoKk=
-=tkR9
+iQIzBAEBCAAdFiEE9Ratt6BphSx8KKAtbYl+31GKAx0FAmB5jBcACgkQbYl+31GK
+Ax0fGw//VAYB3W9tkVvs94D/vkQjLaDIcYI1o69Uusl4vPrUtXbKVWo1evpvKLNQ
+ykBnq8GiYz50uu0zeYRRhm1E18zicI1Gu9qPz28IE3wAysDqsgT9Z5BUwB79T7NN
+XVZAR+F0SxkWw8iuI3f5M5W6MSDX4mr5ruIWkh2f76AjMQtV+cN4z84yQ2rqZJ/n
+nA69X1RJDRIpGPzpe6OvyiFoc0H4kbInKKHWmglvi46lpimKW8AxeDX5EGULxutF
+gZkJVTE5cn+/C+/CFiJJoLbpB6ulkOjT0CRbs9J3p4s1ISCZhw7bF4BVYV1WTF8P
+n3zC+LuGSrZk1oXyBBIRM5fpx1AggGDVt3Tq63krAI7KxMgg4y9rkByJO8pgbave
+zrzeiGp85mYNd4a3WE7FkLgu/XDlxmv1jZD/O3tX4fD732UV/w9WoEcs8m2h/rbD
+KuDkbs0xddatjr/QwJJlscNlamQ8sA1/XzqRGguukX6E8PVTyKhuzjacA0qNTw4J
+2DVwUPso0iiGVORN09489F7uRbrkMHkJ4JOON0IJUxX9yGIPEaPNOVBkuR5j1PWg
+3LEiZyQcigw93vf8tnw9/TwkfajJxFNRHFjf7W30FA1YiN4Ot3FQdeYlzlwhm+0o
+szeSh/fcGYx1UiRa883OhuSeYSe9u/+pM1AO07MnPN+DVp0AjSQ=
+=AyUF
 -----END PGP SIGNATURE-----

--- a/manifests/dcrinstall-v1.6.2-manifests.txt.asc
+++ b/manifests/dcrinstall-v1.6.2-manifests.txt.asc
@@ -4,20 +4,20 @@ Hash: SHA256
 d3b403f9f0c9e754d89043f04289cdcd461a5bcadf56d95753b12d35e64069e7  https://github.com/decred/decred-binaries/releases/download/v1.6.2/decred-v1.6.2-manifest.txt
 3b57a75354007acaf5a635b27a604cb16caeabfe81a2c09e981399b769d6ee95  https://github.com/decred/decred-binaries/releases/download/v1.6.2/dexc-v0.1.5-manifest.txt
 ca9e8202740648542d7b81c9ba1a6f612dc99f919b61db294462256de3a9d27d  https://github.com/decred/decred-release/releases/download/v1.6.2/dcrinstall-v1.6.2-manifest.txt
-b5c04fe37b40119bdc2d329b9c8fb9c0b402a10388fd0837d1a30fb0cd99b344  https://bitcoincore.org/bin/bitcoin-core-0.20.1/SHA256SUMS.asc
+9ae534c116c22cee5bd7e580cf87a5472ceb04c9df46db2cd449add161e3c165  https://bitcoincore.org/bin/bitcoin-core-0.20.1/SHA256SUMS.asc
 -----BEGIN PGP SIGNATURE-----
 
-iQIzBAEBCAAdFiEE9Ratt6BphSx8KKAtbYl+31GKAx0FAmBvKIIACgkQbYl+31GK
-Ax1H9Q//QQy80sxGU/6q8g379U1S9XFhHN/3Wdt7qoCKzINED10cyaCCPcUz9IR9
-khPjhe50un5idyQ/H0s+DrqvxxU0VlkkOL3iJ3Z2BRdAQcbhB29LsPya9SODwZyd
-cGKG1RQaysihh/4SolzQrozECcO0B/RG9DVlV/A5AgzZ84OmfcjLQqInk5Bg0g8T
-4thSyJQy3H78FMBP1wzm3aAUxUJ8puQpiI9ivqUAcW4A6jEgxaqQyxmHCQ150pQO
-joPcRxqUDrKXC4vyKzlAF0SM9kZxVolGJUyY/jugue/BRy0joa8+W94PoEqeNcJq
-lJeeDL8bTg8ToyDXOYMSapN7vocnEg/cu99j2nkhD6ljBJ1xgjtMCf2EpztkiGqQ
-Yu2slZfiLP5OQpajp+8spyk6ebDzCwL/WZi9Rf+GpnHF+iKlahiZGT9cGMR6OS7/
-C6c5upZ3F7gsU+ksY1rWPexGtaIM1lnogPvItKonazgWCkn+3BLDblg0X04wUsI9
-IGSkOhwm2+9Qj1EU/BAaLgenveuiZKLDeI8WsNs1iFR0BIs8T0eUt+IuYrMxsF3E
-7hE3xf52AvJo4gS4PjOmyH8RonRWZiGGppfbmFcOeawgWt3D5NLvFxI9Nk77cqCg
-DFMjUpzHDo/Vc/rtOobN7MQX5q2ddYP9c5gZFdZzFJskqgMUoKk=
-=tkR9
+iQIzBAEBCAAdFiEE9Ratt6BphSx8KKAtbYl+31GKAx0FAmB5jBcACgkQbYl+31GK
+Ax0fGw//VAYB3W9tkVvs94D/vkQjLaDIcYI1o69Uusl4vPrUtXbKVWo1evpvKLNQ
+ykBnq8GiYz50uu0zeYRRhm1E18zicI1Gu9qPz28IE3wAysDqsgT9Z5BUwB79T7NN
+XVZAR+F0SxkWw8iuI3f5M5W6MSDX4mr5ruIWkh2f76AjMQtV+cN4z84yQ2rqZJ/n
+nA69X1RJDRIpGPzpe6OvyiFoc0H4kbInKKHWmglvi46lpimKW8AxeDX5EGULxutF
+gZkJVTE5cn+/C+/CFiJJoLbpB6ulkOjT0CRbs9J3p4s1ISCZhw7bF4BVYV1WTF8P
+n3zC+LuGSrZk1oXyBBIRM5fpx1AggGDVt3Tq63krAI7KxMgg4y9rkByJO8pgbave
+zrzeiGp85mYNd4a3WE7FkLgu/XDlxmv1jZD/O3tX4fD732UV/w9WoEcs8m2h/rbD
+KuDkbs0xddatjr/QwJJlscNlamQ8sA1/XzqRGguukX6E8PVTyKhuzjacA0qNTw4J
+2DVwUPso0iiGVORN09489F7uRbrkMHkJ4JOON0IJUxX9yGIPEaPNOVBkuR5j1PWg
+3LEiZyQcigw93vf8tnw9/TwkfajJxFNRHFjf7W30FA1YiN4Ot3FQdeYlzlwhm+0o
+szeSh/fcGYx1UiRa883OhuSeYSe9u/+pM1AO07MnPN+DVp0AjSQ=
+=AyUF
 -----END PGP SIGNATURE-----


### PR DESCRIPTION
This v1.6.2 manifest commits to the resigned Bitcoin Core release.
There is no change to any Decred software.